### PR TITLE
ui: remove history loader on kosmos screen

### DIFF
--- a/src/features/kosmos/components/templates/exact-market-token-tabs/tabs/transactions/index.tsx
+++ b/src/features/kosmos/components/templates/exact-market-token-tabs/tabs/transactions/index.tsx
@@ -13,6 +13,7 @@ import { upperCase } from 'lodash';
 import { COLORS } from '@constants/colors';
 import { Row, Spinner, Text } from '@components/base';
 import { useMarketTransactions } from '@features/kosmos/lib/query';
+import { isIos } from '@utils/isPlatform';
 
 interface TransactionsHistoryTabProps {
   market: MarketType | undefined;
@@ -29,13 +30,16 @@ export const TransactionsHistoryTab = ({
     market?.id
   );
   const renderRefetchController = useMemo(
-    () => (
-      <RefreshControl
-        onRefresh={refetch}
-        refreshing={isLoading}
-        removeClippedSubviews
-      />
-    ),
+    () =>
+      isIos ? (
+        <RefreshControl
+          onRefresh={refetch}
+          refreshing={isLoading}
+          removeClippedSubviews
+        />
+      ) : (
+        <></>
+      ),
     [isLoading, refetch]
   );
 
@@ -79,7 +83,7 @@ export const TransactionsHistoryTab = ({
         ))}
       </Row>
 
-      {isLoading ? (
+      {isLoading && isIos ? (
         <View style={{ alignItems: 'center', paddingVertical: 10 }}>
           <Spinner />
         </View>


### PR DESCRIPTION
[AMB-5081] https://inc4net.atlassian.net/jira/software/c/projects/AMB/boards/6?assignee=60ae0bbd1ee723006c080e4b&selectedIssue=AMB-5081

remove history loader on kosmos screen when use pull to refresh