### PR TITLE
fix(wallet-connect): add support for 'withdraw' transaction type

### DIFF
--- a/src/features/wallet-connect/components/composite/wallet-connect-tx-approval/index.tsx
+++ b/src/features/wallet-connect/components/composite/wallet-connect-tx-approval/index.tsx
@@ -47,6 +47,7 @@ export const WalletConnectTxApproval = () => {
 
   const isApprovalTx = transaction?.functionName === 'approve';
   const isAmbTransaction = request?.params[0]?.value;
+  const isWithdraw = transaction?.functionName === 'withdraw';
   const isWrapOrUnwrap =
     transaction?.functionName === 'deposit' ||
     transaction?.functionName === 'withdraw';
@@ -194,6 +195,8 @@ export const WalletConnectTxApproval = () => {
                 )} ${
                   isAmbTransaction
                     ? CryptoCurrencyCode.AMB
+                    : isWithdraw
+                    ? CryptoCurrencyCode.SAMB
                     : getTokenSymbolFromDatabase(
                         transaction?.decodedArgs?.addresses?.[0] ?? ''
                       )
@@ -203,8 +206,9 @@ export const WalletConnectTxApproval = () => {
 
         <DetailsRowItem
           field="FEE"
-          value={`${NumberUtils.numberToTransformedLocale(
-            ethers.utils.formatEther(request?.params[0].gas ?? ZERO)
+          value={`${NumberUtils.limitDecimalCount(
+            ethers.utils.formatEther(request?.params[0].gas ?? ZERO),
+            0
           )} ${CryptoCurrencyCode.AMB}`}
         />
       </View>

--- a/src/features/wallet-connect/lib/hooks/use-decode-callback.ts
+++ b/src/features/wallet-connect/lib/hooks/use-decode-callback.ts
@@ -18,6 +18,7 @@ export function useDecodeCallbackData() {
     rawArgs: any
   ): StandardizedDecodedArgs => {
     switch (functionName) {
+      case 'withdraw':
       case 'approve':
         return {
           addresses: [rawArgs.spender],


### PR DESCRIPTION
- Introduced handling for 'withdraw' function in WalletConnectTxApproval component.
- Updated token symbol display logic to differentiate between AMB and SAMB for 'withdraw' transactions.
- Enhanced gas fee display formatting by limiting decimal count for better user readability.
- Modified useDecodeCallbackData hook to include 'withdraw' case for standardized decoded arguments.