### PR TITLE
refactor(wallet-connect): enhance wallet session management and error handling

### DIFF
--- a/src/features/wallet-connect/components/base/wallet-session-item/index.tsx
+++ b/src/features/wallet-connect/components/base/wallet-session-item/index.tsx
@@ -14,9 +14,13 @@ import { styles } from './styles';
 
 interface WalletSessionItemProps {
   connection: SessionTypes.Struct;
+  index: number;
 }
 
-export const WalletSessionItem = ({ connection }: WalletSessionItemProps) => {
+export const WalletSessionItem = ({
+  connection,
+  index
+}: WalletSessionItemProps) => {
   const { t } = useTranslation();
   const { activeSessions, setActiveSessions } =
     useWalletConnectContextSelector();
@@ -43,15 +47,21 @@ export const WalletSessionItem = ({ connection }: WalletSessionItemProps) => {
 
       setActiveSessions(filteredPairings);
     } catch (error) {
+      setActiveSessions((prevState) =>
+        prevState.filter((_, sessionIndex) => sessionIndex !== index)
+      );
+
+      onDismissActiveSessionBottomSheet();
       throw error;
     } finally {
-      setDisconnecting(true);
+      setDisconnecting(false);
     }
   }, [
+    index,
     activeSessions,
     connection.topic,
-    onDismissActiveSessionBottomSheet,
-    setActiveSessions
+    setActiveSessions,
+    onDismissActiveSessionBottomSheet
   ]);
 
   return (

--- a/src/features/wallet-connect/components/composite/wallet-connect-tx-approval/index.tsx
+++ b/src/features/wallet-connect/components/composite/wallet-connect-tx-approval/index.tsx
@@ -74,6 +74,7 @@ export const WalletConnectTxApproval = () => {
           response: response as JsonRpcResponse
         });
       } catch (error) {
+        onDismissWalletConnectBottomSheet();
         throw error;
       }
 
@@ -101,6 +102,7 @@ export const WalletConnectTxApproval = () => {
           response: response as JsonRpcResponse
         });
       } catch (error) {
+        onDismissWalletConnectBottomSheet();
         throw error;
       }
     }

--- a/src/features/wallet-connect/components/composite/wallet-sessions-list/index.tsx
+++ b/src/features/wallet-connect/components/composite/wallet-sessions-list/index.tsx
@@ -16,8 +16,8 @@ export const WalletSessionsList = () => {
 
   const renderWalletSessionListItem = useCallback(
     (args: ListRenderItemInfo<SessionTypes.Struct>) => {
-      const { item: connection } = args;
-      return <WalletSessionItem connection={connection} />;
+      const { item: connection, index } = args;
+      return <WalletSessionItem connection={connection} index={index} />;
     },
     []
   );

--- a/src/features/wallet-connect/lib/hooks/use-wallet-kit-events-manager.ts
+++ b/src/features/wallet-connect/lib/hooks/use-wallet-kit-events-manager.ts
@@ -60,10 +60,12 @@ export function useWalletKitEventsManager(isWalletKitInitiated: boolean) {
   );
 
   const onSessionDelete = useCallback(
-    (event: SessionDeleteEvent) =>
+    (event: SessionDeleteEvent) => {
+      AirDAOEventDispatcher.dispatch(AirDAOEventType.CloseAllModals, null);
       setActiveSessions((prevState) =>
         prevState.filter((session) => session.topic !== event.topic)
-      ),
+      );
+    },
     [setActiveSessions]
   );
 

--- a/src/screens/BarcodeScanner/index.tsx
+++ b/src/screens/BarcodeScanner/index.tsx
@@ -22,8 +22,7 @@ type Props = NativeStackScreenProps<
   'BarcodeScannerScreen'
 >;
 
-const MOCK_ADDRESS =
-  'wc:d022a71abc43dd08e1cff784df8cf9b1c4b1714320100df1477b765ba2748194@2?expiryTimestamp=1736943502&relay-protocol=irn&symKey=289c5eaab9c92811093dc3aa90cfd1456d7b60fb4e6ecebeb48aaff88e2a50fe';
+const MOCK_ADDRESS = 'ethereum:0xF51452e37eEbf3226BcBB25FA4f9F570f176484e';
 
 export const BarcodeScannerScreen = ({ navigation, route }: Props) => {
   const { t } = useTranslation();


### PR DESCRIPTION


- Updated `WalletSessionItem` to accept an `index` prop for better session management.
- Improved error handling in `WalletSessionItem` by dismissing the active session bottom sheet on error.
- Modified `WalletConnectTxApproval` to dismiss the wallet connect bottom sheet on error.
- Adjusted `WalletSessionsList` to pass the `index` prop to `WalletSessionItem`.
- Enhanced `useWalletKitEventsManager` to dispatch an event to close all modals on session deletion.
- Changed mock address in `BarcodeScanner` for consistency with Ethereum format.