### PR TITLE
fix: handle small values and zero formatting

### DIFF
--- a/src/components/templates/AccountList/AccountListItem.tsx
+++ b/src/components/templates/AccountList/AccountListItem.tsx
@@ -1,6 +1,6 @@
 import { formatUnits } from 'ethers/lib/utils';
 import { WalletCard } from '@components/modular';
-import { useAMBPrice, useUSDPrice } from '@hooks';
+import { useAMBPrice, useUSDBigNumberAmount } from '@hooks';
 import { useBalanceOfAddress } from '@hooks/query/useBalanceOfAddress';
 import { AccountListItemProps, CardType } from './AccountList.types';
 
@@ -10,8 +10,7 @@ export const AccountListItem = (props: AccountListItemProps) => {
     account.address
   );
   const { data: ambPrice } = useAMBPrice();
-  const usdBalance = useUSDPrice(Number(ambBalance.ether) || 0);
-
+  const usdBalance = useUSDBigNumberAmount(ambBalance.wei);
   switch (type as CardType) {
     case 'credit-card': {
       return (

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -18,3 +18,4 @@ export * from './useEffectOnce';
 export * from './useBarcodeScanner';
 export * from './useKeyboardContainerStyleWithSafeArea';
 export * from './useContainerWithSafeArea';
+export * from './useUSDBigNumberAmount';

--- a/src/hooks/useUSDBigNumberAmount.ts
+++ b/src/hooks/useUSDBigNumberAmount.ts
@@ -1,0 +1,39 @@
+import { useMemo } from 'react';
+import { BigNumber } from 'ethers';
+import { formatEther, parseUnits } from 'ethers/lib/utils';
+import { lowerCase } from 'lodash';
+import { CryptoCurrencyCode } from '@appTypes';
+import { useCurrenciesStore } from '@entities/currencies/model';
+
+export const useUSDBigNumberAmount = (
+  weiAmount: number | string,
+  symbol: CryptoCurrencyCode | string = CryptoCurrencyCode.AMB
+) => {
+  const { currencies } = useCurrenciesStore();
+
+  return useMemo(() => {
+    const token = currencies.find((token) =>
+      lowerCase(token.symbol).includes(lowerCase(symbol))
+    );
+
+    if (!weiAmount || !token?.bestUSDPrice) return '0.00';
+
+    const priceString = token.bestUSDPrice.toString();
+    const [integerPart, fractionalPart = ''] = priceString.split('.');
+    const tokenPrice = [integerPart, fractionalPart.slice(0, 18)].join('.');
+
+    const priceInWei = parseUnits(tokenPrice, 18);
+    const weiBigNumber = BigNumber.from(weiAmount);
+
+    const usdPrice = priceInWei
+      .mul(weiBigNumber)
+      .div(BigNumber.from(10).pow(18));
+
+    const usdPriceInEther = parseFloat(formatEther(usdPrice));
+    if (usdPriceInEther < 0.01) {
+      return '0.00';
+    }
+
+    return formatEther(usdPrice);
+  }, [weiAmount, currencies, symbol]);
+};

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -126,6 +126,10 @@ const numberToTransformedLocale = (value: string | number) => {
     return '0';
   }
 
+  if (amount < 0.01) {
+    return '0.00';
+  }
+
   const [intPart, floatPart] = amount.toString().split('.');
 
   if (amount % 1 === 0) {


### PR DESCRIPTION
- Added handling for small values (less than 0.01) to ensure proper display.
- If the value is less than 0.01 or equal to zero, it returns '0.00'.
- Improved number formatting for floating-point numbers (2 decimal places) for better display.