### PR TITLE
fix(crypto): improve transaction receipt polling mechanism

### DIFF
--- a/src/lib/crypto/TransferDispatcher.ts
+++ b/src/lib/crypto/TransferDispatcher.ts
@@ -1,3 +1,4 @@
+import * as Clipboard from 'expo-clipboard';
 import Web3 from 'web3';
 import { TransactionConfig } from 'web3-core';
 import Config from '@constants/config';
@@ -113,6 +114,7 @@ class TransferDispatcher {
       // @ts-ignore
       return txReceipt.transactionHash;
     } catch (error) {
+      await Clipboard.setStringAsync(JSON.stringify(error));
       // @ts-ignore
       if (error.message.includes('Returned error: Insufficient funds.')) {
         throw Error('INSUFFICIENT_FUNDS');

--- a/src/lib/crypto/TransferDispatcher.ts
+++ b/src/lib/crypto/TransferDispatcher.ts
@@ -3,14 +3,15 @@ import { TransactionConfig } from 'web3-core';
 import Config from '@constants/config';
 import { delay } from '@utils';
 import erc20 from './erc20';
-const MAX_RETRIES = 5;
+
+const MAX_RETRIES = 7;
 
 class TransferDispatcher {
   private web3: Web3;
 
   constructor() {
     this.web3 = new Web3(new Web3.providers.HttpProvider(Config.NETWORK_URL));
-    this.web3.eth.transactionPollingTimeout = 17;
+    this.web3.eth.transactionPollingTimeout = 15;
   }
 
   private async prepareTransactionConfig(
@@ -120,13 +121,12 @@ class TransferDispatcher {
       try {
         if (!txHash) throw error;
 
-        await delay(1000);
-
         let attempt = 0;
         let receipt;
         while (attempt < MAX_RETRIES) {
           receipt = await this.web3.eth.getTransactionReceipt(txHash);
           if (receipt) break;
+          await delay(2000);
           attempt++;
         }
 

--- a/src/lib/crypto/TransferDispatcher.ts
+++ b/src/lib/crypto/TransferDispatcher.ts
@@ -1,4 +1,3 @@
-import * as Clipboard from 'expo-clipboard';
 import Web3 from 'web3';
 import { TransactionConfig } from 'web3-core';
 import Config from '@constants/config';
@@ -114,7 +113,6 @@ class TransferDispatcher {
       // @ts-ignore
       return txReceipt.transactionHash;
     } catch (error) {
-      await Clipboard.setStringAsync(JSON.stringify(error));
       // @ts-ignore
       if (error.message.includes('Returned error: Insufficient funds.')) {
         throw Error('INSUFFICIENT_FUNDS');

--- a/src/screens/SendFunds/components/confirm-tx/styles.ts
+++ b/src/screens/SendFunds/components/confirm-tx/styles.ts
@@ -20,6 +20,7 @@ export const styles = StyleSheet.create({
   errorFooter: {
     width: '100%',
     justifyContent: 'center',
+    alignItems: 'center',
     marginTop: verticalScale(16),
     rowGap: verticalScale(16)
   },

--- a/src/screens/SendFunds/index.tsx
+++ b/src/screens/SendFunds/index.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Keyboard, View } from 'react-native';
+import { Alert, Keyboard, View } from 'react-native';
 import { CommonActions, useFocusEffect } from '@react-navigation/native';
 import { NativeStackScreenProps } from '@react-navigation/native-stack';
 import * as Clipboard from 'expo-clipboard';
@@ -184,7 +184,15 @@ export const SendFunds = ({ navigation, route }: Props) => {
           });
         }
       } catch (error: unknown) {
-        await Clipboard.setStringAsync(JSON.stringify(error));
+        // TODOO remove it for prod
+        const errorToCopy =
+          error instanceof Error
+            ? { message: error.message, stack: error.stack, name: error.name }
+            : error;
+
+        Alert.alert(errorToCopy?.message || JSON.stringify(error, null, 2));
+
+        await Clipboard.setStringAsync(JSON.stringify(errorToCopy, null, 2));
 
         const errorMessage =
           (error as { message: string })?.message ?? JSON.stringify(error);


### PR DESCRIPTION
- Increase max retry attempts from 5 to 7
- Reduce transaction polling timeout from 17 to 15
- Modify delay strategy between transaction receipt checks
- Remove unnecessary initial delay before receipt polling