### PR TITLE
fix(swap): optimize liquidity pools fetching and initialization

### DIFF
--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -161,7 +161,7 @@ switch (Updates.channel) {
     break;
   }
   default: {
-    Config = envs.prod;
+    Config = envs.testnet;
     break;
   }
 }

--- a/src/screens/Swap/index.tsx
+++ b/src/screens/Swap/index.tsx
@@ -17,6 +17,7 @@ import { useSwapContextSelector } from '@features/swap/context';
 import { useAllLiquidityPools } from '@features/swap/lib/hooks';
 import { useSwapAllBalances } from '@features/swap/lib/hooks/use-swap-all-balances';
 import { FIELD } from '@features/swap/types';
+import { useEffectOnce } from '@hooks';
 import { styles } from './styles';
 
 type Props = NativeStackScreenProps<HomeParamsList, 'SwapScreen'>;
@@ -24,13 +25,17 @@ type Props = NativeStackScreenProps<HomeParamsList, 'SwapScreen'>;
 export const SwapScreen = ({ navigation }: Props) => {
   const { t } = useTranslation();
   useSwapAllBalances();
-  useAllLiquidityPools();
+  const { getAllPoolsCount } = useAllLiquidityPools();
   const {
     bottomSheetTokenARef,
     bottomSheetTokenBRef,
     bottomSheetPreviewSwapRef,
     reset
   } = useSwapContextSelector();
+
+  useEffectOnce(() => {
+    getAllPoolsCount();
+  });
 
   useFocusEffect(
     useCallback(() => {


### PR DESCRIPTION
- Refactor getAllPoolsCount to use Promise.all for concurrent pool fetching
- Add error handling for pool retrieval
- Remove unnecessary useEffect hook
- Update SwapScreen to use useEffectOnce for initializing pools
- Change default config environment to testnet