### PR TITLE
fix: visual bugfix in the "Manage permissions".

### DIFF
--- a/src/components/templates/AllProductPermissions/index.tsx
+++ b/src/components/templates/AllProductPermissions/index.tsx
@@ -66,7 +66,7 @@ export const AllProductPermissions = () => {
         </Text>
         <Spacer value={scale(5)} />
         <Text align="center">
-          {t('browser.remove.no.permissions.subheader').replace('${/n}', '\n')}
+          {t('browser.remove.no.permissions.subheader')}
         </Text>
       </View>
     );

--- a/src/components/templates/AllProductPermissions/index.tsx
+++ b/src/components/templates/AllProductPermissions/index.tsx
@@ -66,7 +66,7 @@ export const AllProductPermissions = () => {
         </Text>
         <Spacer value={scale(5)} />
         <Text align="center">
-          {t('browser.remove.no.permissions.subheader')}
+          {t('browser.remove.no.permissions.subheader').replace('${/n}', '\n')}
         </Text>
       </View>
     );

--- a/src/features/browser/components/templates/bottom-sheet-remove-permissions/index.tsx
+++ b/src/features/browser/components/templates/bottom-sheet-remove-permissions/index.tsx
@@ -59,7 +59,7 @@ export const BottomSheetRemovePermissions = forwardRef<BottomSheetRef>(
           <Row style={styles.buttonsWrapper} justifyContent="space-between">
             <SecondaryButton style={styles.button} onPress={onReject}>
               <Text style={styles.buttonText} color={COLORS.neutral800}>
-                {t('common.reject')}
+                {t('wallet.connect.button.cancel')}
               </Text>
             </SecondaryButton>
             <PrimaryButton
@@ -68,7 +68,7 @@ export const BottomSheetRemovePermissions = forwardRef<BottomSheetRef>(
               onPress={onApprove}
             >
               <Text style={styles.buttonText} color={COLORS.neutral0}>
-                {t('common.approve')}
+                {t('wallet.connect.button.disconnect')}
               </Text>
             </PrimaryButton>
           </Row>

--- a/src/localization/locales/English.json
+++ b/src/localization/locales/English.json
@@ -555,7 +555,7 @@
   "browser.remove.permission.modal.header": "Are you sure?",
   "browser.remove.permission.modal.subheader": "You’ll need to reconnect to use it again.",
   "browser.remove.no.permissions.header": "No Connected Websites",
-  "browser.remove.no.permissions.subheader": "You haven’t connected to any websites yet. ${/n}When you do, they will appear here",
+  "browser.remove.no.permissions.subheader": "You haven’t connected to any websites yet. \nWhen you do, they will appear here",
 
   "browser.approve":{
     "permission": "See your account and suggest transactions",

--- a/src/localization/locales/English.json
+++ b/src/localization/locales/English.json
@@ -555,7 +555,7 @@
   "browser.remove.permission.modal.header": "Are you sure?",
   "browser.remove.permission.modal.subheader": "You’ll need to reconnect to use it again.",
   "browser.remove.no.permissions.header": "No Connected Websites",
-  "browser.remove.no.permissions.subheader": "You haven’t connected to any websites yet. When you do, they will appear here",
+  "browser.remove.no.permissions.subheader": "You haven’t connected to any websites yet. ${/n}When you do, they will appear here",
 
   "browser.approve":{
     "permission": "See your account and suggest transactions",

--- a/src/localization/locales/Turkish.json
+++ b/src/localization/locales/Turkish.json
@@ -558,7 +558,7 @@
   "browser.remove.permission.modal.header": "Emin misiniz?",
   "browser.remove.permission.modal.subheader": "Tekrar kullanmak için yeniden bağlanmanız gerekecek",
   "browser.remove.no.permissions.header": "Bağlı Web Sitesi Yok",
-  "browser.remove.no.permissions.subheader": "Henüz hiçbir web sitesine bağlanmadınız. ${/n}Bağlandığınızda, burada görünecekler",
+  "browser.remove.no.permissions.subheader": "Henüz hiçbir web sitesine bağlanmadınız. \nBağlandığınızda, burada görünecekler",
 
   "browser.approve": {
     "permission": "Hesabınızı görün ve işlem önerin",

--- a/src/localization/locales/Turkish.json
+++ b/src/localization/locales/Turkish.json
@@ -251,7 +251,7 @@
   "settings.about": "Hakkında",
   "settings.help": "Yardım merkezi",
   "settings.manage.wallet": "Cüzdan yönetimi",
-  "settings.manage.permissions": "Manage permissions",
+  "settings.manage.permissions": "!!!Manage permissions",
   "settings.watchlists": "İzleme listesi",
   "settings.explore": "Keşfet",
   "settings.notifications": "Bildirim ayarları",
@@ -558,7 +558,7 @@
   "browser.remove.permission.modal.header": "Emin misiniz?",
   "browser.remove.permission.modal.subheader": "Tekrar kullanmak için yeniden bağlanmanız gerekecek",
   "browser.remove.no.permissions.header": "Bağlı Web Sitesi Yok",
-  "browser.remove.no.permissions.subheader": "Henüz hiçbir web sitesine bağlanmadınız. Bağlandığınızda, burada görünecekler",
+  "browser.remove.no.permissions.subheader": "Henüz hiçbir web sitesine bağlanmadınız. ${/n}Bağlandığınızda, burada görünecekler",
 
   "browser.approve": {
     "permission": "Hesabınızı görün ve işlem önerin",


### PR DESCRIPTION
[AMB-5631] https://inc4net.atlassian.net/jira/software/c/projects/AMB/boards/6?assignee=60ae0bbd1ee723006c080e4b&selectedIssue=AMB-5631

-- rename modal buttons 
-- add split into two lines. when user hasn't connected websites

