### PR TITLE
feat: add new RPC methods for transaction and block retrieval

### DIFF
--- a/src/features/browser/lib/middleware-helpers/ethBlockCore.ts
+++ b/src/features/browser/lib/middleware-helpers/ethBlockCore.ts
@@ -1,0 +1,19 @@
+import { ethers } from 'ethers';
+import Config from '@constants/config';
+import { rpcErrorHandler } from '@features/browser/utils';
+
+export const ethGetBlockNumber = async () => {
+  const provider = new ethers.providers.JsonRpcProvider(Config.NETWORK_URL);
+  try {
+    const blockNumber = await provider.getBlockNumber();
+    return blockNumber;
+  } catch (error) {
+    rpcErrorHandler('getBlockNumber', error);
+    return null;
+  }
+};
+
+export const ethBlockNumber = async () => {
+  const provider = new ethers.providers.JsonRpcProvider(Config.NETWORK_URL);
+  return provider.blockNumber;
+};

--- a/src/features/browser/lib/middleware-helpers/ethTransactionCore.ts
+++ b/src/features/browser/lib/middleware-helpers/ethTransactionCore.ts
@@ -1,0 +1,23 @@
+import { ethers } from 'ethers';
+import Config from '@constants/config';
+import { rpcErrorHandler } from '@features/browser/utils';
+
+export const ethGetTransactionByHash = async (hash: string) => {
+  const provider = new ethers.providers.JsonRpcProvider(Config.NETWORK_URL);
+  try {
+    return await provider.getTransaction(hash);
+  } catch (error) {
+    rpcErrorHandler('getTransactionByHash', error);
+    return null;
+  }
+};
+
+export const ethGetTransactionReceipt = async (hash: string) => {
+  const provider = new ethers.providers.JsonRpcProvider(Config.NETWORK_URL);
+  try {
+    return await provider.getTransactionReceipt(hash);
+  } catch (error) {
+    rpcErrorHandler('getTransactionReceipt', error);
+    return null;
+  }
+};

--- a/src/features/browser/lib/middleware-helpers/index.ts
+++ b/src/features/browser/lib/middleware-helpers/index.ts
@@ -7,3 +7,5 @@ export * from './ethSignTransaction';
 export * from './ethSendTransaction';
 export * from './ethAccounts';
 export * from './ethCall';
+export * from './ethTransactionCore';
+export * from './ethBlockCore';

--- a/src/features/browser/lib/middleware-helpers/walletGetPermissions.ts
+++ b/src/features/browser/lib/middleware-helpers/walletGetPermissions.ts
@@ -6,7 +6,7 @@ import {
 import { rpcErrorHandler } from '@features/browser/utils';
 import { permissionsHandler } from '../permissions-handler';
 
-interface WalletGetPermissionsArgs {
+export interface WalletGetPermissionsArgs {
   response: {
     result: {
       parentCapability: Permissions;

--- a/src/features/browser/lib/rpc-middleware.ts
+++ b/src/features/browser/lib/rpc-middleware.ts
@@ -11,6 +11,9 @@ import {
   ethSendTransaction,
   ethSignTransaction,
   ethSignTypesData,
+  ethGetBlockNumber,
+  ethGetTransactionByHash,
+  ethGetTransactionReceipt,
   handleWalletConnection,
   personalSign,
   walletGetPermissions,
@@ -122,6 +125,18 @@ export async function handleWebViewMessage({
           });
           break;
 
+        case RPCMethods.EthGetTransactionByHash:
+          response.result = await ethGetTransactionByHash(params[0]);
+          break;
+
+        case RPCMethods.EthGetBlockNumber:
+          response.result = await ethGetBlockNumber();
+          break;
+
+        case RPCMethods.EthGetTransactionReceipt:
+          response.result = await ethGetTransactionReceipt(params[0]);
+          break;
+
         // eth_call
         case RPCMethods.EthCall: {
           await ethCall({ data: params[0], response });
@@ -189,7 +204,7 @@ export async function handleWebViewMessage({
 
         // wallet_getPermissions
         case RPCMethods.WalletGetPermissions:
-          await walletGetPermissions({ response });
+          await walletGetPermissions({ response: response as any });
           break;
 
         // eth_signTransaction

--- a/src/features/browser/types/rpc-methods.types.ts
+++ b/src/features/browser/types/rpc-methods.types.ts
@@ -26,7 +26,11 @@ export enum RPCMethods {
   EthSignTypedDataV4 = 'eth_signTypedData_v4',
   EthSignTypedData = 'eth_signTypedData',
   EthCall = 'eth_call',
-  EthEstimateGas = 'eth_estimateGas'
+  EthEstimateGas = 'eth_estimateGas',
+  EthGetTransactionByHash = 'eth_getTransactionByHash',
+  EthGetBlockNumber = 'eth_getBlockNumber',
+  EthBlockNumber = 'eth_blockNumber',
+  EthGetTransactionReceipt = 'eth_getTransactionReceipt'
 }
 
 export type TransactionParams = {


### PR DESCRIPTION
- Implemented ethGetTransactionByHash, ethGetBlockNumber, and ethGetTransactionReceipt in rpc-middleware.
- Updated RPCMethods enum to include new methods.
- Exported additional helper functions in middleware-helpers for transaction and block operations.
- Changed WalletGetPermissionsArgs interface to export for broader access.