### PR TITLE
feat(rpc-methods): add EthBlockNumber method to RPC middleware and streamline ethGetBlockNumber function

### DIFF
--- a/src/features/browser/lib/middleware-helpers/ethBlockCore.ts
+++ b/src/features/browser/lib/middleware-helpers/ethBlockCore.ts
@@ -5,15 +5,9 @@ import { rpcErrorHandler } from '@features/browser/utils';
 export const ethGetBlockNumber = async () => {
   const provider = new ethers.providers.JsonRpcProvider(Config.NETWORK_URL);
   try {
-    const blockNumber = await provider.getBlockNumber();
-    return blockNumber;
+    return await provider.getBlockNumber();
   } catch (error) {
     rpcErrorHandler('getBlockNumber', error);
     return null;
   }
-};
-
-export const ethBlockNumber = async () => {
-  const provider = new ethers.providers.JsonRpcProvider(Config.NETWORK_URL);
-  return provider.blockNumber;
 };

--- a/src/features/browser/lib/rpc-middleware.ts
+++ b/src/features/browser/lib/rpc-middleware.ts
@@ -129,6 +129,7 @@ export async function handleWebViewMessage({
           response.result = await ethGetTransactionByHash(params[0]);
           break;
 
+        case RPCMethods.EthBlockNumber:
         case RPCMethods.EthGetBlockNumber:
           response.result = await ethGetBlockNumber();
           break;


### PR DESCRIPTION


- Introduced a new case for RPCMethods.EthBlockNumber in the RPC middleware to handle block number requests.
- Simplified the ethGetBlockNumber function by directly returning the result of provider.getBlockNumber().