### PR TITLE
fix: update product filtering logic in parseWebProduct to handle uid checks more clearly

### DIFF
--- a/src/features/products/utils/parseWebProduct.tsx
+++ b/src/features/products/utils/parseWebProduct.tsx
@@ -22,10 +22,12 @@ export const parseWebProduct = (
   return products
     .filter((product) => product.uri && product.name)
     .filter((product) => product?.platforms?.includes(Platform.OS))
-    .filter(
-      (product) =>
-        APP_VERSION >= MIN_AMBRODEO_VERSION || product?.uid !== 'amb_rodeo'
-    )
+    .filter((product) => {
+      if (product?.uid === 'amb_rodeo') {
+        return APP_VERSION >= MIN_AMBRODEO_VERSION;
+      }
+      return true;
+    })
     .map((product: BrowserItemModel) => {
       const icon = product.icon ? (
         <SvgXml xml={product.icon} width={56} height={56} />


### PR DESCRIPTION

- Simplified the filtering logic for products with uid 'amb_rodeo' based on the app version.
- Ensured that products are only filtered out if the app version is below the minimum required version.