### PR TITLE
feat(swap!): automatically execute DEX tokens from AMB Rodeo & TokenLogo tries to parse logo from rodeo tokens

### DIFF
--- a/Providers.tsx
+++ b/Providers.tsx
@@ -1,14 +1,14 @@
 import { FC, PropsWithChildren } from 'react';
-import { ApolloClient, InMemoryCache, ApolloProvider } from '@apollo/client';
+import { ApolloProvider } from '@apollo/client';
 import { DatabaseProvider } from '@nozbe/watermelondb/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
-import Config from '@constants/config';
 import { LocalizationProvider } from '@contexts';
 import { Database } from '@database';
 import { BridgeContextProvider } from '@features/bridge/context';
 import { SwapContextProvider } from '@features/swap/context';
 import { WalletConnectContextProvider } from '@features/wallet-connect/context';
+import { client } from '@lib';
 import { combineComponents } from '@utils';
 
 const queryClient = new QueryClient();
@@ -18,11 +18,6 @@ const WrappedQueryClientProvider: FC = ({ children }: PropsWithChildren) => (
 );
 
 const ApolloQueryProvider = ({ children }: PropsWithChildren) => {
-  const client = new ApolloClient({
-    uri: Config.CURRENCY_GRAPH_URL,
-    cache: new InMemoryCache()
-  });
-
   return <ApolloProvider client={client}>{children}</ApolloProvider>;
 };
 

--- a/src/components/animations/Shimmer/index.tsx
+++ b/src/components/animations/Shimmer/index.tsx
@@ -12,11 +12,13 @@ import Reanimated, {
 interface ShimmerLoaderProps {
   width: DimensionValue;
   height: DimensionValue;
+  borderRadius?: number;
 }
 
 export const ShimmerLoader = ({
   width = '100%',
-  height = 150
+  height = 150,
+  borderRadius = 4
 }: Partial<ShimmerLoaderProps>) => {
   const translateX = useSharedValue(-Dimensions.get('window').width);
 
@@ -35,7 +37,7 @@ export const ShimmerLoader = ({
   }, [translateX]);
 
   return (
-    <View style={{ ...styles.container, width, height }}>
+    <View style={{ ...styles.container, width, height, borderRadius }}>
       <Reanimated.View style={[styles.shimmer, animatedStyle]}>
         <LinearGradient
           colors={['#E0E0E0', '#F0F0F0', '#E0E0E0']}

--- a/src/components/base/TokenImageIpfsWithShimmer/index.tsx
+++ b/src/components/base/TokenImageIpfsWithShimmer/index.tsx
@@ -1,0 +1,55 @@
+import { memo, useCallback, useMemo, useState } from 'react';
+import { View, Image } from 'react-native';
+import { ShimmerLoader } from '@components/animations';
+import { styles } from './styles';
+
+interface TokenImageWithShimmerProps {
+  src: string;
+  scale?: number;
+}
+
+const TokenImageIpfsWithShimmerMemo = ({
+  src,
+  scale = 1
+}: TokenImageWithShimmerProps) => {
+  const [loading, setLoading] = useState(false);
+
+  const size = useMemo(() => scale * 32, [scale]);
+
+  const onLoadStart = useCallback(() => setLoading(true), []);
+  const onLoadEnd = useCallback(() => setLoading(false), []);
+
+  const imageSource = useMemo(
+    () => ({
+      uri: `https://ipfs.io/ipfs/${src}`
+    }),
+    [src]
+  );
+
+  return (
+    <View style={[styles.container, { width: size, height: size }]}>
+      <View style={styles.innerRelativeContainer}>
+        {loading && (
+          <ShimmerLoader
+            width={size}
+            height={size}
+            borderRadius={Number.MAX_SAFE_INTEGER}
+          />
+        )}
+      </View>
+      <Image
+        resizeMode="cover"
+        onLoadStart={onLoadStart}
+        onLoadEnd={onLoadEnd}
+        source={imageSource}
+        style={{
+          width: size,
+          height: size,
+          borderRadius: Number.MAX_SAFE_INTEGER
+        }}
+      />
+    </View>
+  );
+};
+
+export const TokenImageIpfsWithShimmer = memo(TokenImageIpfsWithShimmerMemo);

--- a/src/components/base/TokenImageIpfsWithShimmer/styles.ts
+++ b/src/components/base/TokenImageIpfsWithShimmer/styles.ts
@@ -1,0 +1,17 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  container: {
+    justifyContent: 'center',
+    alignContent: 'center',
+    borderRadius: Number.MAX_SAFE_INTEGER,
+    position: 'relative'
+  },
+  innerRelativeContainer: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0
+  }
+});

--- a/src/components/base/index.ts
+++ b/src/components/base/index.ts
@@ -12,3 +12,4 @@ export * from './Spinner';
 export * from './Switch';
 export { TextInput } from './Input/Input.text';
 export { NumberInput } from './Input/Input.number';
+export { TokenImageIpfsWithShimmer } from './TokenImageIpfsWithShimmer';

--- a/src/components/templates/AccountActions/components/Swap.tsx
+++ b/src/components/templates/AccountActions/components/Swap.tsx
@@ -25,7 +25,7 @@ export const Swap = ({ disabled }: SwapActionProps) => {
   const disclaimerModalRef = useRef<BottomSheetRef>(null);
 
   const navigateToSwap = () => {
-    if (!isIos) {
+    if (isIos) {
       const swapItem = browserConfig.products.find(
         (item) => (item.id = ProductSequence.Astra)
       );

--- a/src/components/templates/AccountActions/components/Swap.tsx
+++ b/src/components/templates/AccountActions/components/Swap.tsx
@@ -25,7 +25,7 @@ export const Swap = ({ disabled }: SwapActionProps) => {
   const disclaimerModalRef = useRef<BottomSheetRef>(null);
 
   const navigateToSwap = () => {
-    if (isIos) {
+    if (!isIos) {
       const swapItem = browserConfig.products.find(
         (item) => (item.id = ProductSequence.Astra)
       );

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -52,6 +52,8 @@ const envs = {
     CHAIN_ID_HEX: '0x414e',
     CURRENCY_GRAPH_URL:
       'https://graph-node-api.ambrosus.io/subgraphs/name/airdao/astra-price-test-b',
+    AMBRODEO_TOKENS_GRAPH_URL:
+      'https://graph-node-api.ambrosus.io/subgraphs/name/airdao/ambrodeo',
     HBR_LIQUIDITY_POOL: '0xA89621016D945408a556ECcb4A10c0122aB852F2',
     HBR_TOKEN_ADDRESS: '0xd09270E917024E75086e27854740871F1C8E0E10',
     BROWSER_CONFIG:
@@ -99,6 +101,8 @@ const envs = {
     CHAIN_ID_HEX: '0x414e',
     CURRENCY_GRAPH_URL:
       'https://graph-node-api.ambrosus.io/subgraphs/name/airdao/astra-price-test-b',
+    AMBRODEO_TOKENS_GRAPH_URL:
+      'https://graph-node-api.ambrosus.io/subgraphs/name/airdao/ambrodeo',
     HBR_LIQUIDITY_POOL: '0xA89621016D945408a556ECcb4A10c0122aB852F2',
     HBR_TOKEN_ADDRESS: '0xd09270E917024E75086e27854740871F1C8E0E10',
     BROWSER_CONFIG:
@@ -146,6 +150,8 @@ const envs = {
     CHAIN_ID_HEX: '0x5618',
     CURRENCY_GRAPH_URL:
       'https://graph-node-api.ambrosus.io/subgraphs/name/airdao/astra-price-test-b',
+    AMBRODEO_TOKENS_GRAPH_URL:
+      'https://graph-node-api.ambrosus-test.io/subgraphs/name/airdao/ambrodeo',
     HBR_LIQUIDITY_POOL: '0x255b5ff5026f198c83575d9a1A4561fe820ab92e',
     HBR_TOKEN_ADDRESS: '0x7B58Cbb7c4Ff2E53F8c4405606D0A7AF707ab00b',
     BROWSER_CONFIG:
@@ -169,7 +175,7 @@ switch (Updates.channel) {
     break;
   }
   default: {
-    Config = envs.testnet as TConfig;
+    Config = envs.stage as TConfig;
     break;
   }
 }

--- a/src/entities/amb-rodeo-tokens/lib/hooks/index.ts
+++ b/src/entities/amb-rodeo-tokens/lib/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useRodeoTokensListQuery } from './use-rodeo-tokens-list-query';

--- a/src/entities/amb-rodeo-tokens/lib/hooks/use-rodeo-tokens-list-query.ts
+++ b/src/entities/amb-rodeo-tokens/lib/hooks/use-rodeo-tokens-list-query.ts
@@ -1,0 +1,20 @@
+import { useMemo } from 'react';
+import { useQuery } from '@apollo/client';
+import { RodeoToken } from '@entities/amb-rodeo-tokens/types';
+import { ApolloEndpointsKeys } from '@lib';
+import { AMBRODEO_TOKENS } from '../rodeo-tokens.graph';
+
+type TokensQuery = {
+  tokens: RodeoToken[];
+};
+
+export function useRodeoTokensListQuery() {
+  const { data, loading } = useQuery<TokensQuery>(AMBRODEO_TOKENS, {
+    pollInterval: 60000, // Poll every minute,
+    context: { apiName: ApolloEndpointsKeys.AMBRODEO_TOKENS }
+  });
+
+  const tokens = useMemo(() => data?.tokens || [], [data]);
+
+  return { tokens, loading };
+}

--- a/src/entities/amb-rodeo-tokens/lib/hooks/use-rodeo-tokens-list-query.ts
+++ b/src/entities/amb-rodeo-tokens/lib/hooks/use-rodeo-tokens-list-query.ts
@@ -1,5 +1,6 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useQuery } from '@apollo/client';
+import { useRodeoTokensStore } from '@entities/amb-rodeo-tokens/model';
 import { RodeoToken } from '@entities/amb-rodeo-tokens/types';
 import { ApolloEndpointsKeys } from '@lib';
 import { AMBRODEO_TOKENS } from '../rodeo-tokens.graph';
@@ -9,12 +10,20 @@ type TokensQuery = {
 };
 
 export function useRodeoTokensListQuery() {
+  const { tokens: allRodeoTokens, onChangeRodeoTokens } = useRodeoTokensStore();
+
   const { data, loading } = useQuery<TokensQuery>(AMBRODEO_TOKENS, {
     pollInterval: 60000, // Poll every minute,
     context: { apiName: ApolloEndpointsKeys.AMBRODEO_TOKENS }
   });
 
   const tokens = useMemo(() => data?.tokens || [], [data]);
+
+  useEffect(() => {
+    if (allRodeoTokens.length !== tokens.length) {
+      onChangeRodeoTokens(tokens);
+    }
+  }, [tokens, allRodeoTokens, onChangeRodeoTokens]);
 
   return { tokens, loading };
 }

--- a/src/entities/amb-rodeo-tokens/lib/index.ts
+++ b/src/entities/amb-rodeo-tokens/lib/index.ts
@@ -1,0 +1,2 @@
+export { AMBRODEO_TOKENS } from './rodeo-tokens.graph';
+export * from './hooks';

--- a/src/entities/amb-rodeo-tokens/lib/rodeo-tokens.graph.ts
+++ b/src/entities/amb-rodeo-tokens/lib/rodeo-tokens.graph.ts
@@ -1,0 +1,22 @@
+import { gql } from '@apollo/client';
+
+export const AMBRODEO_TOKENS = gql`
+  query AmbrodeoTokens(
+    $where: Token_filter = { onDex: true }
+    $first: Int = 1000
+    $orderBy: Token_orderBy = onDexSince
+    $orderDirection: OrderDirection = desc
+  ) {
+    tokens(
+      where: $where
+      first: $first
+      orderBy: $orderBy
+      orderDirection: $orderDirection
+    ) {
+      id
+      data
+      name
+      symbol
+    }
+  }
+`;

--- a/src/entities/amb-rodeo-tokens/model/index.ts
+++ b/src/entities/amb-rodeo-tokens/model/index.ts
@@ -1,0 +1,1 @@
+export { useRodeoTokensStore } from './rodeo-tokens.store';

--- a/src/entities/amb-rodeo-tokens/model/rodeo-tokens.store.ts
+++ b/src/entities/amb-rodeo-tokens/model/rodeo-tokens.store.ts
@@ -1,0 +1,12 @@
+import { create } from 'zustand';
+import { RodeoToken } from '../types';
+
+interface RodeoTokensStore {
+  tokens: RodeoToken[];
+  onChangeRodeoTokens: (tokens: RodeoToken[]) => void;
+}
+
+export const useRodeoTokensStore = create<RodeoTokensStore>((set) => ({
+  tokens: [],
+  onChangeRodeoTokens: (tokens) => set({ tokens })
+}));

--- a/src/entities/amb-rodeo-tokens/types/index.ts
+++ b/src/entities/amb-rodeo-tokens/types/index.ts
@@ -1,0 +1,1 @@
+export * from './token';

--- a/src/entities/amb-rodeo-tokens/types/token.ts
+++ b/src/entities/amb-rodeo-tokens/types/token.ts
@@ -1,0 +1,6 @@
+export type RodeoToken = {
+  data: string;
+  id: string;
+  name: string;
+  symbol: string;
+};

--- a/src/entities/currencies/lib/hooks/use-currencies-query.ts
+++ b/src/entities/currencies/lib/hooks/use-currencies-query.ts
@@ -3,13 +3,15 @@ import { useQuery } from '@apollo/client';
 import { GET_CURRENCIES_QUERY } from '@entities/currencies/lib/currencies.graph';
 import { useCurrenciesStore } from '@entities/currencies/model';
 import { AwaitCurrencyResponse } from '@entities/currencies/types';
+import { ApolloEndpointsKeys } from '@lib';
 
 export function useCurrenciesQuery() {
   const { onSetCurrencies } = useCurrenciesStore();
   const { data, refetch } = useQuery<AwaitCurrencyResponse>(
     GET_CURRENCIES_QUERY,
     {
-      pollInterval: 3 * 60 * 1e3
+      pollInterval: 3 * 60 * 1e3,
+      context: { apiName: ApolloEndpointsKeys.CURRENCY }
     }
   );
 

--- a/src/features/swap/components/templates/bottom-sheet-tokens-list/index.tsx
+++ b/src/features/swap/components/templates/bottom-sheet-tokens-list/index.tsx
@@ -5,11 +5,12 @@ import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Spacer } from '@components/base';
 import { BottomSheet, BottomSheetRef } from '@components/composite';
-import Config from '@constants/config';
 import { DEVICE_HEIGHT } from '@constants/variables';
+import { useRodeoTokensListQuery } from '@entities/amb-rodeo-tokens/lib';
 import { BottomSheetTokenItem } from '@features/swap/components/modular';
 import { useSwapAllBalances } from '@features/swap/lib/hooks/use-swap-all-balances';
 import { FIELD, SelectedTokensKeys, SwapToken } from '@features/swap/types';
+import { transformTokensObject } from '@features/swap/utils';
 import { useForwardedRef } from '@hooks';
 import { scale } from '@utils';
 import { styles } from './styles';
@@ -25,6 +26,8 @@ export const BottomSheetTokensList = forwardRef<
   const { t } = useTranslation();
   const bottomSheetRef = useForwardedRef(ref);
   const { balances } = useSwapAllBalances();
+
+  const { tokens } = useRodeoTokensListQuery();
 
   const label = type === FIELD.TOKEN_A ? t('swap.pay') : t('swap.receive');
 
@@ -55,7 +58,7 @@ export const BottomSheetTokensList = forwardRef<
       <View style={{ maxHeight: DEVICE_HEIGHT / 2.25 }}>
         <FlatList
           maxToRenderPerBatch={4}
-          data={Config.SWAP_TOKENS}
+          data={transformTokensObject(tokens)}
           showsVerticalScrollIndicator={false}
           contentContainerStyle={styles.container}
           keyExtractor={(item) => item.symbol}

--- a/src/features/swap/entities/tokens.ts
+++ b/src/features/swap/entities/tokens.ts
@@ -58,26 +58,6 @@ export const SWAP_SUPPORTED_TOKENS = {
         address: '0x5ECAddC28FcFc0bEDF94858c6D771420672ad2CF',
         name: 'X3NA',
         symbol: 'X3NA'
-      },
-      {
-        address: '0xFE7d3723d14a22AD51417669647B2db36249032E',
-        name: 'AMBull',
-        symbol: 'BULL'
-      },
-      {
-        address: '0x3013cb367D85b484A2e89d4b0d6556588f1c339f',
-        name: 'MAKE AIRDAO GREAT AGAIN',
-        symbol: 'MAGA'
-      },
-      {
-        address: '0x3EcF647262896A91291504c5206A77d2a4fFfCfF',
-        name: 'Merica',
-        symbol: 'Merica'
-      },
-      {
-        address: '0x33ebbf03738EF0a916DDB84bDc25C4816084eF1F',
-        name: 'NOTHING CLUB APE',
-        symbol: 'NTC'
       }
     ],
     testnet: [

--- a/src/features/swap/lib/hooks/use-all-liquidity-pools.ts
+++ b/src/features/swap/lib/hooks/use-all-liquidity-pools.ts
@@ -49,8 +49,8 @@ export function useAllLiquidityPools() {
 
               return {
                 pairAddress,
-                token0,
-                token1
+                token0: token0.toLowerCase(),
+                token1: token1.toLowerCase()
               };
             } catch (error) {
               if (__DEV__) {
@@ -115,10 +115,16 @@ export function useAllLiquidityPools() {
           TOKEN_B?.address ?? ''
         ]);
 
-        const targetSet = new Set([addressFrom, addressTo]);
+        const targetSet = new Set([
+          addressFrom.toLowerCase(),
+          addressTo.toLowerCase()
+        ]);
 
         return allPairsRef.current.find((pair) => {
-          const pairSet = new Set([pair.token0, pair.token1]);
+          const pairSet = new Set([
+            pair.token0.toLowerCase(),
+            pair.token1.toLowerCase()
+          ]);
           return (
             targetSet.size === pairSet.size &&
             [...targetSet].every((value) => pairSet.has(value))

--- a/src/features/swap/lib/hooks/use-swap-all-balances.ts
+++ b/src/features/swap/lib/hooks/use-swap-all-balances.ts
@@ -1,8 +1,8 @@
 import { useCallback } from 'react';
 import { ethers } from 'ethers';
-import Config from '@constants/config';
+import { useRodeoTokensListQuery } from '@entities/amb-rodeo-tokens/lib';
 import { useSwapContextSelector } from '@features/swap/context';
-import { SwapToken } from '@features/swap/types';
+import { transformTokensObject } from '@features/swap/utils';
 import { initialBalances } from '@features/swap/utils/balances';
 import { useSwapMultiplyBalance } from './use-swap-multiply-balance';
 
@@ -11,17 +11,18 @@ export function useSwapAllBalances() {
   const { balances, setBalances, setBalancesLoading } =
     useSwapContextSelector();
 
-  const tokens: SwapToken[] = Config.SWAP_TOKENS;
+  const { tokens } = useRodeoTokensListQuery();
 
   const fetchAllBalances = useCallback(async () => {
     const isInitialBalance =
       JSON.stringify(balances) === JSON.stringify(initialBalances);
+
     try {
       setBalancesLoading(isInitialBalance);
       const balancePromises: Promise<Record<
         string,
         ethers.BigNumber
-      > | null>[] = tokens.map(async (token) => {
+      > | null>[] = transformTokensObject(tokens).map(async (token) => {
         const balance = await getTokenBalance(token);
         return balance ? { [token.address]: balance } : null;
       });

--- a/src/features/swap/utils/balances.ts
+++ b/src/features/swap/utils/balances.ts
@@ -1,8 +1,8 @@
 import { ethers } from 'ethers';
-import Config from '@constants/config';
-import { SwapToken } from '../types';
+import { useRodeoTokensStore } from '@entities/amb-rodeo-tokens/model';
+import { transformTokensObject } from './transform-tokens-object';
 
-const tokens = Config.SWAP_TOKENS as SwapToken[];
+const tokens = transformTokensObject(useRodeoTokensStore.getState().tokens);
 
 export const initialBalances = tokens.reduce<
   Record<string, ethers.BigNumber>[]

--- a/src/features/swap/utils/index.ts
+++ b/src/features/swap/utils/index.ts
@@ -10,3 +10,4 @@ export { dexValidators } from './validators';
 export { SwapStringUtils } from './transformers';
 export * from './swap-args.callback';
 export * from './is-trade-better';
+export * from './transform-tokens-object';

--- a/src/features/swap/utils/multi-route.ts
+++ b/src/features/swap/utils/multi-route.ts
@@ -1,5 +1,5 @@
-import { SWAP_SUPPORTED_TOKENS } from '@features/swap/entities';
-import { environment } from '@utils/environment';
+import { useRodeoTokensStore } from '@entities/amb-rodeo-tokens/model';
+import { transformTokensObject } from './transform-tokens-object';
 import { addresses } from './wrap-native-address';
 
 export const MAX_HOPS = 3;
@@ -32,13 +32,14 @@ export const generateAllPossibleRoutes = (
   path: string[],
   maxHops = MAX_HOPS
 ): string[][] => {
+  const { tokens: ambRodeoTokens } = useRodeoTokensStore.getState();
   const [startToken, endToken] = path;
   if (!startToken || !endToken) return [];
 
   // Check if path includes addresses.SAMB
   const includesSAMB = path.includes(addresses.SAMB);
 
-  const availableTokens = SWAP_SUPPORTED_TOKENS.tokens[environment]
+  const availableTokens = transformTokensObject(ambRodeoTokens)
     .filter(
       (token) =>
         !ignoreTokenAddresses.includes(token.address) &&
@@ -78,7 +79,8 @@ export const generateAllPossibleRoutes = (
 export const extractArrayOfMiddleMultiHopAddresses = (
   path: string[]
 ): string[] => {
-  const availableTokens = SWAP_SUPPORTED_TOKENS.tokens[environment].filter(
+  const { tokens } = useRodeoTokensStore.getState();
+  const availableTokens = transformTokensObject(tokens).filter(
     (token) => token.symbol !== 'SAMB'
   );
 

--- a/src/features/swap/utils/transform-tokens-object.ts
+++ b/src/features/swap/utils/transform-tokens-object.ts
@@ -1,0 +1,14 @@
+import Config from '@constants/config';
+import { RodeoToken } from '@entities/amb-rodeo-tokens/types';
+import { SwapToken } from '../types';
+
+export const transformTokensObject = (newTokens: RodeoToken[]): SwapToken[] => {
+  return [
+    ...Config.SWAP_TOKENS,
+    ...newTokens.map((token) => {
+      const { id: address, name, symbol } = token;
+
+      return { address, name, symbol };
+    })
+  ];
+};

--- a/src/features/swap/utils/wrap-native-address.ts
+++ b/src/features/swap/utils/wrap-native-address.ts
@@ -1,13 +1,16 @@
 import { ethers } from 'ethers';
-import Config from '@constants/config';
+import { useRodeoTokensStore } from '@entities/amb-rodeo-tokens/model';
 import { TOKEN_ADDRESSES } from '@features/swap/entities';
 import { SwapToken } from '@features/swap/types';
 import { environment } from '@utils/environment';
+import { transformTokensObject } from './transform-tokens-object';
 
 export const addresses = TOKEN_ADDRESSES[environment];
 
 export function isNativeWrapped(path: string[]) {
-  const wrappedPath = Config.SWAP_TOKENS.find(
+  const { tokens } = useRodeoTokensStore.getState();
+
+  const wrappedPath = transformTokensObject(tokens).find(
     (token: SwapToken) => token.symbol === 'SAMB'
   )?.address;
 
@@ -15,11 +18,13 @@ export function isNativeWrapped(path: string[]) {
 }
 
 export function wrapNativeAddress(path: string[]): [string, string] {
+  const { tokens } = useRodeoTokensStore.getState();
   const nativeAddress = ethers.constants.AddressZero;
 
   const replacementAddress =
-    Config.SWAP_TOKENS.find((token: SwapToken) => token.symbol === 'SAMB')
-      ?.address ?? '';
+    transformTokensObject(tokens).find(
+      (token: SwapToken) => token.symbol === 'SAMB'
+    )?.address ?? '';
 
   return path.map((token) =>
     token === nativeAddress ? replacementAddress : token

--- a/src/lib/apollo/endpoints.ts
+++ b/src/lib/apollo/endpoints.ts
@@ -1,0 +1,11 @@
+import Config from '@constants/config';
+
+export enum ApolloEndpointsKeys {
+  AMBRODEO_TOKENS = 'GRAPH_AMBRODEO_ENDPOINT',
+  CURRENCY = 'GRAPH_CURRENCY_ENDPOINT'
+}
+
+export const ApolloEndpoints = {
+  [ApolloEndpointsKeys.AMBRODEO_TOKENS]: Config.AMBRODEO_TOKENS_GRAPH_URL,
+  [ApolloEndpointsKeys.CURRENCY]: Config.CURRENCY_GRAPH_URL
+} as const;

--- a/src/lib/apollo/index.ts
+++ b/src/lib/apollo/index.ts
@@ -1,0 +1,2 @@
+export * from './instance';
+export * from './endpoints';

--- a/src/lib/apollo/instance.ts
+++ b/src/lib/apollo/instance.ts
@@ -1,0 +1,21 @@
+import { ApolloClient, InMemoryCache, createHttpLink } from '@apollo/client';
+import { ApolloEndpoints, ApolloEndpointsKeys } from './endpoints';
+
+const httpLink = createHttpLink({
+  uri: ({ getContext }) => {
+    const { apiName } = getContext();
+
+    if (apiName === ApolloEndpointsKeys.AMBRODEO_TOKENS)
+      return ApolloEndpoints[ApolloEndpointsKeys.AMBRODEO_TOKENS];
+
+    if (apiName === ApolloEndpointsKeys.CURRENCY)
+      return ApolloEndpoints[ApolloEndpointsKeys.CURRENCY];
+
+    return ApolloEndpoints[ApolloEndpointsKeys.CURRENCY];
+  }
+});
+
+export const client = new ApolloClient({
+  link: httpLink,
+  cache: new InMemoryCache()
+});

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -6,3 +6,4 @@ export { default as PermissionService } from './permission';
 export { default as AirDAOKeysStorage } from './crypto/AirDAOKeysStorage';
 export * from './sentry.core';
 export * from './provider-error-handler';
+export * from './apollo';

--- a/src/screens/Swap/index.tsx
+++ b/src/screens/Swap/index.tsx
@@ -8,6 +8,7 @@ import { Button } from '@components/base';
 import { Header } from '@components/composite';
 import { SettingsFilledIcon } from '@components/svg/icons';
 import { COLORS } from '@constants/colors';
+import { useRodeoTokensListQuery } from '@entities/amb-rodeo-tokens/lib';
 import {
   BottomSheetPreviewSwap,
   BottomSheetTokensList,
@@ -24,7 +25,9 @@ type Props = NativeStackScreenProps<HomeParamsList, 'SwapScreen'>;
 
 export const SwapScreen = ({ navigation }: Props) => {
   const { t } = useTranslation();
+  useRodeoTokensListQuery();
   useSwapAllBalances();
+
   const { getAllPoolsCount } = useAllLiquidityPools();
   const {
     bottomSheetTokenARef,

--- a/src/utils/hexlify.ts
+++ b/src/utils/hexlify.ts
@@ -1,0 +1,15 @@
+import { arrayify, toUtf8String } from 'ethers/lib/utils';
+
+export const fromHexlifyToObject = <T>(hex: string): T => {
+  try {
+    if (typeof hex !== 'string') {
+      throw new TypeError('Input must be a string');
+    }
+
+    const utf8String = toUtf8String(arrayify(hex));
+
+    return JSON.parse(utf8String);
+  } catch {
+    return {} as T;
+  }
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -37,3 +37,4 @@ export * from './deviceSpecification';
 export * from './wrap-callback-with-error-handler';
 export * from './hasDigits';
 export * from './estimated-gas';
+export * from './hexlify';


### PR DESCRIPTION

- Removed direct ApolloClient instantiation in Providers component, now using a pre-configured client from the lib.
- Enhanced ShimmerLoader component to accept an optional borderRadius prop for better customization.
- Updated TokenLogo component to utilize the new TokenImageIpfsWithShimmer for rendering token images.
- Refactored BottomSheetTokensList and useSwapAllBalances to leverage the new rodeo tokens query for dynamic token data.
- Cleaned up unused token definitions in SWAP_SUPPORTED_TOKENS for improved maintainability.